### PR TITLE
Added "probably unsupported device" gathering.

### DIFF
--- a/certification_tool/src/certification_tool/configs/config.yaml
+++ b/certification_tool/src/certification_tool/configs/config.yaml
@@ -6,6 +6,10 @@ log_settings: logging.cfg
 config_file: /tmp/netconfig.yaml
 
 report:
+  skipped_pci_classes:
+    '0101': 'IDE interface'
+    '0601': 'ISA bridge'
+    '0604': 'PCI bridge'
   mail:
     smtp_server: "smtp.gmail.com"
     mail_to: "fuel-certification@mirantis.com"

--- a/certification_tool/src/certification_tool/main.py
+++ b/certification_tool/src/certification_tool/main.py
@@ -76,9 +76,9 @@ ssh_cmd_templ = "ssh {ssh_opts} root@{ip} {cmd}"
 
 def gather_hw_info_subprocess(nodes, config, splitter='!' * 60):
     res = []
-    slots = []
     try:
         for node in nodes:
+            slots = []
             res.append(splitter)
             res.append("Node: %s %s" % (node.ip, " ".join(node.roles)))
             ip = node.ip


### PR DESCRIPTION
General idea is device, which not in pci.ids base
will named like "Device {device_id}" in the "lspci -vmn" ouput.

So, when we get some device, unspecified in pci database -
it probably will not be supported.
